### PR TITLE
Fixed compilation and object file linkage of test project

### DIFF
--- a/Explorer/projects/Tests/Tests.cpp
+++ b/Explorer/projects/Tests/Tests.cpp
@@ -4,6 +4,23 @@
 
 #include <iostream>
 
+// Context Menu Includes
+// NOTE
+#include "ExplorerDialog.h"
+
+#include <shellapi.h>
+#include <shlwapi.h>
+#include <shlobj.h>
+#include <dbt.h>
+
+#include "Explorer.h"
+#include "ExplorerResource.h"
+#include "ContextMenu.h"
+#include "NewDlg.h"
+#include "NppInterface.h"
+#include "ToolTip.h"
+#include "resource.h"
+
 using namespace std;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 

--- a/Explorer/projects/Tests/Tests.cpp
+++ b/Explorer/projects/Tests/Tests.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 
 // Context Menu Includes
-// NOTE
+/*
 #include "ExplorerDialog.h"
 
 #include <shellapi.h>
@@ -19,7 +19,10 @@
 #include "NewDlg.h"
 #include "NppInterface.h"
 #include "ToolTip.h"
-#include "resource.h"
+#include "resource.h"*/
+
+#include <ShlObj.h>
+#include "ContextMenu.h"
 
 using namespace std;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
@@ -40,6 +43,11 @@ namespace Tests
 		TEST_METHOD(SettingsLoadTest)
 		{
 			//loadSettings();
+		}
+
+		TEST_METHOD(ContextMenuInit)
+		{
+			ContextMenu cm;
 		}
 
 		// Write your unit tests here or in a separate testing file.

--- a/Explorer/projects/Tests/Tests.vcxproj
+++ b/Explorer/projects/Tests/Tests.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{95304D7E-E07E-4714-8C36-A177F8CFCDFE}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Tests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -94,8 +94,8 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\..\Common\Ccpp;..\..\src\NewDlg\;..\..\src\PropDlg\;..\..\src\Toolbar\;..\..\src\FileDlg\;..\..\src\FileList\;.;..\..\src\;..\..\src\MISC\;..\..\src\HelpDlg\;..\..\src\OptionDlg\;..\..\src\PureDnD\;..\..\..\NativeLang\src;%(AdditionalIncludeDirectories);$(VCInstallDir)UnitTest\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(WindowsSDK_LibraryPath);$(WindowsSDK_IncludePathPath);..\..\..\Common\Ccpp;..\..\src\NewDlg\;..\..\src\PropDlg\;..\..\src\Toolbar\;..\..\src\FileDlg\;..\..\src\FileList\;.;..\..\src\;..\..\src\MISC\;..\..\src\HelpDlg\;..\..\src\OptionDlg\;..\..\src\PureDnD\;..\..\..\NativeLang\src;%(AdditionalIncludeDirectories);$(VCInstallDir)UnitTest\include</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;EXPLORER_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>

--- a/Explorer/projects/Tests/Tests.vcxproj
+++ b/Explorer/projects/Tests/Tests.vcxproj
@@ -99,11 +99,12 @@
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Comctl32.lib;Mpr.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;..\VC2017\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Comctl32.lib;Mpr.lib;..\VC2017\x64\Debug\Explorer.lib;..\VC2017\x64\Debug\*.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/Explorer/projects/VC2017/Explorer.vcxproj
+++ b/Explorer/projects/VC2017/Explorer.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{BA345CAF-580B-4786-8699-717F831D10CF}</ProjectGuid>
     <SccProjectName />
     <SccLocalPath />
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
There were a variety of issues with the way the overall unit testing project was attempting to derive references to the object files generated by the base project. I managed to use an (albeit delicate) solution to manually add all .obj files generated in the compilation directory for Explorer.lib + etc (using the *.obj wildcard) and fed them directly as input to the linker for Tests.cpp & the associated project.

This is a workaround for an underlying issue with how Visual Studio handles dependency resolution when the output is split across a variety of disparate directories.

I also updated the windows platform version so you may have to make sure all of your local libraries are up to date to continue to work on this project. The visual studio installer should be able to do this automatically if you tell it to.

This also contains my **first unit test** so if it causes technical issues and you need to reject it, let me know so I can save my results to the document first.

![image](https://user-images.githubusercontent.com/14202750/75594728-8ab7e080-5a3e-11ea-985b-efc04e1d5888.png)
