### PR TITLE
Context Menu Patches

### DIFF
--- a/Explorer/projects/Tests/Tests.cpp
+++ b/Explorer/projects/Tests/Tests.cpp
@@ -11,10 +11,8 @@
 #include <string>
 
 // Context Menu Includes
-
-#include <ShlObj.h>
 #include "ContextMenu.h"
-#include <atlcomcli.h>
+
 
 // Directory Index Includes
 #include "DirectoryIndex.h"

--- a/Explorer/src/MISC/ContextMenu.cpp
+++ b/Explorer/src/MISC/ContextMenu.cpp
@@ -75,21 +75,24 @@ BOOL ContextMenu::GetContextMenu (void ** ppContextMenu, int & iMenuType)
 
 	if (icm1)
 	{	// since we got an IContextMenu interface we can now obtain the higher version interfaces via that
-		if (icm1->QueryInterface (IID_IContextMenu3, ppContextMenu) == NOERROR)
+		if (icm1->QueryInterface(IID_IContextMenu3, ppContextMenu) == NOERROR)
 			iMenuType = 3;
-		else if (icm1->QueryInterface (IID_IContextMenu2, ppContextMenu) == NOERROR)
+		else if (icm1->QueryInterface(IID_IContextMenu2, ppContextMenu) == NOERROR)
 			iMenuType = 2;
 
-		if (*ppContextMenu) 
+		if (*ppContextMenu)
 			icm1->Release(); // we can now release version 1 interface, cause we got a higher one
-		else 
-		{	
+		else
+		{
 			iMenuType = 1;
 			*ppContextMenu = icm1;	// since no higher versions were found
 		}							// redirect ppContextMenu to version 1 interface
 	}
 	else
+	{
+		throw new std::domain_error("IContextInterface could not be determined");
 		return (FALSE);	// something went wrong
+	}
 	
 	return (TRUE); // success
 }
@@ -1095,6 +1098,7 @@ bool ContextMenu::Str2CB(LPCTSTR str2cpy)
 	if (hglbCopy == NULL) 
 	{ 
 		::CloseClipboard(); 
+		throw std::exception("Could not allocate HGLOBAL hglbCopy");
 		return false; 
 	} 
 

--- a/Explorer/src/MISC/ContextMenu.cpp
+++ b/Explorer/src/MISC/ContextMenu.cpp
@@ -167,16 +167,11 @@ UINT ContextMenu::ShowContextMenu(HINSTANCE hInst, HWND hWndNpp, HWND hWndParent
 	::GetModuleFileName((HMODULE)hInst, szPath, MAX_PATH);
 
 	/* get version information */
-	CommunicationInfo	ci;
-	ci.srcModuleName	= PathFindFileName(szPath);
-	ci.internalMsg		= NPEM_GETVERDWORD;
-	ci.info				= &dwExecVer;
+	CommunicationInfo	ci = MakeCommunicationInfo(szPath, NPEM_GETVERDWORD, &dwExecVer);
 	::SendMessage(hWndNpp, NPPM_MSGTOPLUGIN, (WPARAM)exProp.nppExecProp.szAppName, (LPARAM)&ci);
 	
 	/* get acivity state of NppExec */
-	ci.srcModuleName	= PathFindFileName(szPath);
-	ci.internalMsg		= NPEM_GETSTATE;
-	ci.info				= &dwExecState;
+	ci = MakeCommunicationInfo(szPath, NPEM_GETSTATE, &dwExecState);
 	::SendMessage(hWndNpp, NPPM_MSGTOPLUGIN, (WPARAM)exProp.nppExecProp.szAppName, (LPARAM)&ci);
 
 	/* Add notepad menu items */
@@ -465,6 +460,21 @@ void ContextMenu::ConfigurePIDHandles(LPCONTEXTMENU pContextMenu, int& menuType)
 	}
 	return;
 }
+
+/// <summary>
+/// Creates a struct used to help with tracking inter-application 
+/// communication based off of the current Notepad++ executable
+/// ID.
+/// </summary>
+CommunicationInfo ContextMenu::MakeCommunicationInfo(TCHAR srcModuleName[MAX_PATH], long intMsg, DWORD* version)
+{
+	CommunicationInfo ci;
+	ci.srcModuleName = PathFindFileName(srcModuleName);
+	ci.internalMsg = intMsg;
+	ci.info = version;
+	return ci;
+}
+
 
 
 void ContextMenu::InvokeCommand (LPCONTEXTMENU pContextMenu, UINT idCommand)

--- a/Explorer/src/MISC/ContextMenu.cpp
+++ b/Explorer/src/MISC/ContextMenu.cpp
@@ -25,8 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include "ContextMenu.h"
 
-#include "FavesDialog.h"
-#include "nppexec_msgs.h"
+
 
 
 IContextMenu2 * g_IContext2		= NULL;

--- a/Explorer/src/MISC/ContextMenu.cpp
+++ b/Explorer/src/MISC/ContextMenu.cpp
@@ -336,79 +336,7 @@ UINT ContextMenu::ShowContextMenu(HINSTANCE hInst, HWND hWndNpp, HWND hWndParent
 	{
 
 	/************************************* modification for notepad ***********************************/
-
-		switch (idCommand)
-		{
-			case CTX_RENAME:
-			{
-				Rename();
-				break;
-			}
-			case CTX_NEW_FILE:
-			{
-				newFile();
-				break;
-			}
-			case CTX_NEW_FOLDER:
-			{
-				newFolder();
-				break;
-			}
-			case CTX_FIND_IN_FILES:
-			{
-				findInFiles();
-				break;
-			}
-			case CTX_OPEN:
-			{
-				openFile();
-				break;
-			}
-			case CTX_OPEN_DIFF_VIEW:
-			{
-				openFileInOtherView();
-				break;
-			}
-			case CTX_OPEN_NEW_INST:
-			{
-				openFileInNewInstance();
-				break;
-			}
-			case CTX_OPEN_CMD:
-			{
-				openPrompt();
-				break;
-			}
-			case CTX_ADD_TO_FAVES:
-			{
-				addToFaves(isFolder);
-				break;
-			}
-			case CTX_FULL_PATH:
-			{
-				addFullPathsCB();
-				break;
-			}
-			case CTX_FULL_FILES:
-			{
-				addFileNamesCB();
-				break;
-			}
-			case CTX_GOTO_SCRIPT_PATH:
-			{
-				openScriptPath(hInst);
-				break;
-			}
-			default: /* and greater */
-			{
-				if ((idCommand >= CTX_START_SCRIPT) && (idCommand <= (CTX_START_SCRIPT + _strNppScripts.size())))
-				{
-					startNppExec(hInst, idCommand - CTX_START_SCRIPT);
-				}
-				break;
-			}
-		}
-
+		NPPContextAction(idCommand, isFolder); // Shouldn't have to pass isFolder :(
 	/*****************************************************************************************************/
 
 	}
@@ -475,6 +403,88 @@ CommunicationInfo ContextMenu::MakeCommunicationInfo(TCHAR srcModuleName[MAX_PAT
 	return ci;
 }
 
+/// <summary>
+/// Performs a core Notepad++ action as if it were queried through this
+/// context menu instance.
+/// </summary>
+/// <param name="idCommand">The <see cref="eContextMenuID"/> to execute.</param>
+/// <param name="">
+/// <remarks>We should add a check to enforce idCommand's type.
+/// We should also not depend on isFolder.</remarks>
+void ContextMenu::NPPContextAction(UINT idCommand, bool isFolder)
+{
+	switch (idCommand)
+	{
+	case CTX_RENAME:
+	{
+		Rename();
+		break;
+	}
+	case CTX_NEW_FILE:
+	{
+		newFile();
+		break;
+	}
+	case CTX_NEW_FOLDER:
+	{
+		newFolder();
+		break;
+	}
+	case CTX_FIND_IN_FILES:
+	{
+		findInFiles();
+		break;
+	}
+	case CTX_OPEN:
+	{
+		openFile();
+		break;
+	}
+	case CTX_OPEN_DIFF_VIEW:
+	{
+		openFileInOtherView();
+		break;
+	}
+	case CTX_OPEN_NEW_INST:
+	{
+		openFileInNewInstance();
+		break;
+	}
+	case CTX_OPEN_CMD:
+	{
+		openPrompt();
+		break;
+	}
+	case CTX_ADD_TO_FAVES:
+	{
+		addToFaves(isFolder);
+		break;
+	}
+	case CTX_FULL_PATH:
+	{
+		addFullPathsCB();
+		break;
+	}
+	case CTX_FULL_FILES:
+	{
+		addFileNamesCB();
+		break;
+	}
+	case CTX_GOTO_SCRIPT_PATH:
+	{
+		openScriptPath(_hInst);
+		break;
+	}
+	default: /* and greater */
+	{
+		if ((idCommand >= CTX_START_SCRIPT) && (idCommand <= (CTX_START_SCRIPT + _strNppScripts.size())))
+		{
+			startNppExec(_hInst, idCommand - CTX_START_SCRIPT);
+		}
+		break;
+	}
+	}
+}
 
 
 void ContextMenu::InvokeCommand (LPCONTEXTMENU pContextMenu, UINT idCommand)

--- a/Explorer/src/MISC/ContextMenu.h
+++ b/Explorer/src/MISC/ContextMenu.h
@@ -40,7 +40,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <commctrl.h>
 #include <atlcomcli.h>
 #include <ShlObj.h>
-
+#include <stdexcept>
 
 
 struct __declspec(uuid("000214e6-0000-0000-c000-000000000046")) IShellFolder;
@@ -90,6 +90,9 @@ public:
 	void SetObjects(std::wstring strObject);
 	void SetObjects(std::vector<std::wstring> strArray);
 	UINT ShowContextMenu(HINSTANCE hInst, HWND hWndNpp, HWND hWndParent, POINT pt, bool normal = true);
+
+protected:
+	void ConfigurePIDHandles(LPCONTEXTMENU pContextMenu, int& menuType);
 
 private:
 	static LRESULT CALLBACK HookWndProc (HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);

--- a/Explorer/src/MISC/ContextMenu.h
+++ b/Explorer/src/MISC/ContextMenu.h
@@ -92,6 +92,7 @@ public:
 	UINT ShowContextMenu(HINSTANCE hInst, HWND hWndNpp, HWND hWndParent, POINT pt, bool normal = true);
 
 	static CommunicationInfo MakeCommunicationInfo(TCHAR srcModuleName[MAX_PATH], long intMsg, DWORD* version);
+	void NPPContextAction(UINT idCommand, bool isFolder);
 
 protected:
 	void ConfigurePIDHandles(LPCONTEXTMENU pContextMenu, int& menuType);

--- a/Explorer/src/MISC/ContextMenu.h
+++ b/Explorer/src/MISC/ContextMenu.h
@@ -32,10 +32,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "ExplorerResource.h"
 #include "NewDlg.h"
 #include "window.h"
+#include "FavesDialog.h"
+#include "nppexec_msgs.h"
 #include <malloc.h>
 #include <vector>
 #include <string>
 #include <commctrl.h>
+#include <atlcomcli.h>
+#include <ShlObj.h>
+
 
 
 struct __declspec(uuid("000214e6-0000-0000-c000-000000000046")) IShellFolder;

--- a/Explorer/src/MISC/ContextMenu.h
+++ b/Explorer/src/MISC/ContextMenu.h
@@ -91,6 +91,8 @@ public:
 	void SetObjects(std::vector<std::wstring> strArray);
 	UINT ShowContextMenu(HINSTANCE hInst, HWND hWndNpp, HWND hWndParent, POINT pt, bool normal = true);
 
+	static CommunicationInfo MakeCommunicationInfo(TCHAR srcModuleName[MAX_PATH], long intMsg, DWORD* version);
+
 protected:
 	void ConfigurePIDHandles(LPCONTEXTMENU pContextMenu, int& menuType);
 


### PR DESCRIPTION
I wrote several patches for the file [ContextMenu.cpp](https://github.com/titswort/npp-explorer-plugin/blob/master/Explorer/src/MISC/ContextMenu.cpp). They are described as follows:

--

Context menu method decomposition (Eric): The class ContextMenu.cpp did not adhere to good object oriented design. Its most visible violations were resolved, but more work remains to be done here (See V.A Unresolved Issues)
**CRITICAL:** ContextMenu.cpp was not aware of its own dependencies and required another class that appeared earlier in compilation including them separately. (#35)
Insufficient method decomposition (e.g. #15). This resulted in monstrous methods with exceedingly complex lengths and preconditions. This also inhibited the module’s reusability.
While writing this patch, automated regression testing was run after each commit (See IV.D Regression Testing).
Wasted computational resources (e.g. #14): This was a fast patch that causes a dynamic constructor to only be called once it is known to be necessary.
Context menu better failure (Eric): A longstanding tradition in C has been to fail “cleanly” by returning an integer from all core methods that serves as a sort of “status code”. The output of the function would be in the modification of pass-by-reference parameters. However, recent years and technological advances have given rise to a preferred way of handling error states: Exceptions. This patch is an attempt to implement exceptions as an error system into the file ContextMenu.cpp in places where clear, critical errors occur but instead the program continues running in an irrecoverable state. The unpatched design relies on each and every calling instance to know how to react to each status code and potentially obscuring or cascading bugs, which is one of the problems that exceptions solve. (#7). It is unclear at this time if this patch resolved all of these issues.

_All .cpp and .h file patches conducted by Eric Prather were directed towards the Context Menu class rather than the Directory Index system because the former was in a much worse state, while the latter was well-designed and implemented. While writing these patches, automated regression testing was run after each commit (See IV.D Regression Testing)._

--

Includes #37, but I wanted to put this pull request out now so everybody could clearly see how I did the patches, ran the tests, and etcetera.